### PR TITLE
use edm::one module to be MT safe

### DIFF
--- a/GeneratorInterface/RivetInterface/interface/ParticleLevelProducer.h
+++ b/GeneratorInterface/RivetInterface/interface/ParticleLevelProducer.h
@@ -2,7 +2,7 @@
 #define GeneratorInterface_RivetInterface_ParticleLevelProducer_H
 
 #include "FWCore/Framework/interface/Frameworkfwd.h"
-#include "FWCore/Framework/interface/stream/EDProducer.h"
+#include "FWCore/Framework/interface/one/EDProducer.h"
 #include "FWCore/Framework/interface/Event.h"
 #include "FWCore/Framework/interface/MakerMacros.h"
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
@@ -15,7 +15,7 @@
 #include "Rivet/AnalysisHandler.hh"
 #include "GeneratorInterface/RivetInterface/interface/RivetAnalysis.h"
 
-class ParticleLevelProducer : public edm::stream::EDProducer<>
+class ParticleLevelProducer : public edm::one::EDProducer<edm::one::SharedResources>
 {
 public:
   ParticleLevelProducer(const edm::ParameterSet& pset);

--- a/GeneratorInterface/RivetInterface/plugins/ParticleLevelProducer.cc
+++ b/GeneratorInterface/RivetInterface/plugins/ParticleLevelProducer.cc
@@ -20,6 +20,8 @@ ParticleLevelProducer::ParticleLevelProducer(const edm::ParameterSet& pset):
   srcToken_(consumes<edm::HepMCProduct>(pset.getParameter<edm::InputTag>("src"))),
   rivetAnalysis_(new Rivet::RivetAnalysis(pset))
 {
+  usesResource();
+
   genVertex_ = reco::Particle::Point(0,0,0);
 
   produces<reco::GenParticleCollection>("neutrinos");


### PR DESCRIPTION
edm::one module makes unique instance, preventing MT issues. 
Documentation: https://twiki.cern.ch/twiki/bin/view/CMSPublic/FWMultithreadedFrameworkOneModuleInterface